### PR TITLE
Feat : 공지사항 & 고객센터 신고 테이블 정의, 엔티티 작성

### DIFF
--- a/src/main/java/com/sparta/project/delivery/inquiry/entity/Inquiry.java
+++ b/src/main/java/com/sparta/project/delivery/inquiry/entity/Inquiry.java
@@ -1,0 +1,46 @@
+package com.sparta.project.delivery.inquiry.entity;
+
+import com.sparta.project.delivery.common.BaseEntity;
+import com.sparta.project.delivery.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+@Entity
+@Table(name = "p_inquiry")
+public class Inquiry extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "inquiry_id", updatable = false, nullable = false)
+    private String inquiryId;
+
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Setter
+    @Column(nullable = false)
+    private String title;
+
+    @Setter
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @Setter
+    @Column(length = 50, nullable = false)
+    private String status;
+
+    @Setter
+    @Lob
+    @Column
+    private String response;
+
+
+
+}

--- a/src/main/java/com/sparta/project/delivery/notice/entity/Notice.java
+++ b/src/main/java/com/sparta/project/delivery/notice/entity/Notice.java
@@ -1,0 +1,29 @@
+package com.sparta.project.delivery.notice.entity;
+
+import com.sparta.project.delivery.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+@Entity
+@Table(name = "p_notice")
+public class Notice extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "notice_id", updatable = false, nullable = false)
+    private String noticeId;
+
+    @Setter
+    @Column(nullable = false)
+    private String title;
+
+    @Setter
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+}


### PR DESCRIPTION
## 공지사항과 고객센터 신고를 위한 엔티티 작성

### 테이블 명세 수정
- [테이블 sheet](https://docs.google.com/spreadsheets/d/1uwZLw9s6ZMzNlAAeAuM5yBRPREWHeJXCLg87wVl1-vQ/edit?gid=0#gid=0)

### Feat
- Notice : 공지사항 테이블 
- Inquiry : 고객센터 신고 테이블

### TODO
유저 security 작성되면 api 작성


#48 