### PR TITLE
Feat : 고객센터 신고 API 작성

### DIFF
--- a/src/main/java/com/sparta/project/delivery/inquiry/constant/InquirySearchType.java
+++ b/src/main/java/com/sparta/project/delivery/inquiry/constant/InquirySearchType.java
@@ -1,0 +1,15 @@
+package com.sparta.project.delivery.inquiry.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum InquirySearchType {
+    TITLE("제목"),
+    CONTENT("본문");
+
+    private final String description;
+
+    InquirySearchType(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/sparta/project/delivery/inquiry/constant/InquiryStatus.java
+++ b/src/main/java/com/sparta/project/delivery/inquiry/constant/InquiryStatus.java
@@ -1,0 +1,17 @@
+package com.sparta.project.delivery.inquiry.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum InquiryStatus {
+
+    RECEIVED("접수"),     // 접수 상태
+    COMPLETED("완료");    // 완료 상태 -> 답변 완료, 처리 중 상태는 생략
+
+    private final String description;
+
+    InquiryStatus(String description) {
+        this.description = description;
+    }
+
+}

--- a/src/main/java/com/sparta/project/delivery/inquiry/controller/InquiryController.java
+++ b/src/main/java/com/sparta/project/delivery/inquiry/controller/InquiryController.java
@@ -1,0 +1,81 @@
+package com.sparta.project.delivery.inquiry.controller;
+
+
+import com.sparta.project.delivery.inquiry.constant.InquirySearchType;
+import com.sparta.project.delivery.inquiry.dto.InquiryRequest;
+import com.sparta.project.delivery.inquiry.dto.InquiryResponse;
+import com.sparta.project.delivery.inquiry.dto.InquirySetReplyRequest;
+import com.sparta.project.delivery.inquiry.service.InquiryService;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+
+//TODO : 유저 권한 조건 추가
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/inquiry")
+public class InquiryController {
+
+    private final InquiryService inquiryService;
+
+    //신고자 OR 관리자 권한에 따른 로직 나누기
+    @GetMapping
+    public Page<InquiryResponse> getAll(
+            @RequestParam(required = false) InquirySearchType searchType,
+            @RequestParam(required = false) String searchValue,
+            @ParameterObject @PageableDefault(
+                    size = 10, sort = {"createdAt", "updatedAt"}, direction = Sort.Direction.DESC
+            ) Pageable pageable
+            //            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        return inquiryService.getAllInquiry(searchType, searchValue, pageable).map(InquiryResponse::from);
+    }
+
+
+    //신고자 OR 관리자 권한에 따른 로직 나누기
+    @GetMapping("/{inquiryId}")
+    public InquiryResponse getOne(
+            //            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable String inquiryId) {
+        return InquiryResponse.from(inquiryService.getInquiry(inquiryId));
+    }
+
+    //TODO : user 추가 , set status 접수 중
+    @PostMapping
+    public String create(
+//            @AuthenticationPrincipal UserDetailsImpl userDetails
+            @RequestBody InquiryRequest request
+    ) {
+//        return inquiryService.createInquiry(request.toDto(userDetails.getEmail()));
+        return "create";
+    }
+
+    //신고 사항 수정 -> 제목, 내용
+    @PutMapping("/{inquiryId}")
+    public InquiryResponse update(@PathVariable String inquiryId, @RequestBody InquiryRequest request) {
+        return InquiryResponse.from(inquiryService.updateInquiry(inquiryId, request.toDto()));
+    }
+
+
+    // 신고자만 삭제 가능
+    @DeleteMapping("/{inquiryId}")
+    public String delete(
+            @PathVariable String inquiryId) {
+        return inquiryService.deleteInquiry(inquiryId);
+    }
+
+    // TODO : 관리자만 사용 권한
+    @PostMapping("/{inquiryId}")
+    public String reply(
+            @PathVariable String inquiryId,
+            @RequestBody InquirySetReplyRequest request
+    ){
+        return inquiryService.replyToInquiry(inquiryId, request);
+    }
+}

--- a/src/main/java/com/sparta/project/delivery/inquiry/dto/InquiryDto.java
+++ b/src/main/java/com/sparta/project/delivery/inquiry/dto/InquiryDto.java
@@ -1,0 +1,45 @@
+package com.sparta.project.delivery.inquiry.dto;
+
+import com.sparta.project.delivery.inquiry.constant.InquiryStatus;
+import com.sparta.project.delivery.inquiry.entity.Inquiry;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record InquiryDto(
+        String inquiryId,
+        String userEmail,
+        String title,
+        String content,
+        InquiryStatus status,
+        String response,
+        Boolean isPublic,
+        Boolean isDeleted,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime updatedAt,
+        String updatedBy,
+        LocalDateTime deletedAt,
+        String deletedBy
+) {
+
+    public static InquiryDto from(Inquiry entity) {
+        return InquiryDto.builder()
+                .inquiryId(entity.getInquiryId())
+                .userEmail(entity.getUser().getEmail())
+                .title(entity.getTitle())
+                .content(entity.getContent())
+                .status(entity.getStatus())
+                .response(entity.getResponse())
+                .isPublic(entity.getIsPublic())
+                .isDeleted(entity.getIsDeleted())
+                .createdAt(entity.getCreatedAt())
+                .createdBy(entity.getCreatedBy())
+                .updatedAt(entity.getUpdatedAt())
+                .updatedBy(entity.getUpdatedBy())
+                .deletedAt(entity.getDeletedAt())
+                .deletedBy(entity.getDeletedBy())
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/project/delivery/inquiry/dto/InquiryRequest.java
+++ b/src/main/java/com/sparta/project/delivery/inquiry/dto/InquiryRequest.java
@@ -1,0 +1,26 @@
+package com.sparta.project.delivery.inquiry.dto;
+
+import com.sparta.project.delivery.inquiry.constant.InquiryStatus;
+
+public record InquiryRequest(
+        String title,
+        String content
+) {
+
+    public InquiryDto toDto(String userEmail){
+        return InquiryDto.builder()
+                .userEmail(userEmail)
+                .title(title)
+                .content(content)
+                .status(InquiryStatus.RECEIVED)
+                .build();
+    }
+
+
+    public InquiryDto toDto(){
+        return InquiryDto.builder()
+                .title(title)
+                .content(content)
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/project/delivery/inquiry/dto/InquiryResponse.java
+++ b/src/main/java/com/sparta/project/delivery/inquiry/dto/InquiryResponse.java
@@ -1,0 +1,33 @@
+package com.sparta.project.delivery.inquiry.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record InquiryResponse(
+        String inquiryId,
+        String title,
+        String userEmail,
+        String content,
+        Boolean isPublic,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime updatedAt,
+        String updatedBy
+) {
+
+    public static InquiryResponse from(InquiryDto dto) {
+        return InquiryResponse.builder()
+                .inquiryId(dto.inquiryId())
+                .title(dto.title())
+                .userEmail(dto.userEmail())
+                .content(dto.content())
+                .isPublic(dto.isPublic())
+                .createdAt(dto.createdAt())
+                .createdBy(dto.createdBy())
+                .updatedAt(dto.updatedAt())
+                .updatedBy(dto.updatedBy())
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/project/delivery/inquiry/dto/InquirySetReplyRequest.java
+++ b/src/main/java/com/sparta/project/delivery/inquiry/dto/InquirySetReplyRequest.java
@@ -1,0 +1,7 @@
+package com.sparta.project.delivery.inquiry.dto;
+
+
+public record InquirySetReplyRequest(
+        String response
+) {
+}

--- a/src/main/java/com/sparta/project/delivery/inquiry/entity/Inquiry.java
+++ b/src/main/java/com/sparta/project/delivery/inquiry/entity/Inquiry.java
@@ -1,6 +1,7 @@
 package com.sparta.project.delivery.inquiry.entity;
 
 import com.sparta.project.delivery.common.BaseEntity;
+import com.sparta.project.delivery.inquiry.constant.InquiryStatus;
 import com.sparta.project.delivery.user.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -33,8 +34,9 @@ public class Inquiry extends BaseEntity {
     private String content;
 
     @Setter
+    @Enumerated(EnumType.STRING)
     @Column(length = 50, nullable = false)
-    private String status;
+    private InquiryStatus status;
 
     @Setter
     @Lob

--- a/src/main/java/com/sparta/project/delivery/inquiry/repository/InquiryRepository.java
+++ b/src/main/java/com/sparta/project/delivery/inquiry/repository/InquiryRepository.java
@@ -1,0 +1,13 @@
+package com.sparta.project.delivery.inquiry.repository;
+
+import com.sparta.project.delivery.inquiry.entity.Inquiry;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InquiryRepository extends JpaRepository<Inquiry, String> {
+
+    Page<Inquiry> findByUser_Email(String userEmail, Pageable pageable);
+    Page<Inquiry> findByTitleContainingIgnoreCase(String title, Pageable pageable);
+    Page<Inquiry> findByContentContaining(String content, Pageable pageable);
+}

--- a/src/main/java/com/sparta/project/delivery/inquiry/service/InquiryService.java
+++ b/src/main/java/com/sparta/project/delivery/inquiry/service/InquiryService.java
@@ -1,0 +1,97 @@
+package com.sparta.project.delivery.inquiry.service;
+
+
+import com.sparta.project.delivery.inquiry.constant.InquirySearchType;
+import com.sparta.project.delivery.inquiry.constant.InquiryStatus;
+import com.sparta.project.delivery.inquiry.dto.InquiryDto;
+import com.sparta.project.delivery.inquiry.dto.InquiryRequest;
+import com.sparta.project.delivery.inquiry.dto.InquirySetReplyRequest;
+import com.sparta.project.delivery.inquiry.entity.Inquiry;
+import com.sparta.project.delivery.inquiry.repository.InquiryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+//TODO : 유저 조건 추가 -> 쿼리 수정
+@Service
+@RequiredArgsConstructor
+public class InquiryService {
+    private final InquiryRepository inquiryRepository;
+//    private final UserRepository userRepository;
+
+
+    @Transactional(readOnly = true)
+    public Page<InquiryDto> getAllInquiry(InquirySearchType searchType, String searchValue, Pageable pageable) {
+        if (searchValue == null || searchValue.isBlank()) {
+//            return inquiryRepository.findByUser_Email(pageable).map(InquiryDto::from);
+            return inquiryRepository.findAll(pageable).map(InquiryDto::from);
+        }
+
+        //TODO : status 조건 추가 생각해보기
+        return switch (searchType){
+            case TITLE -> inquiryRepository.findByTitleContainingIgnoreCase(searchValue, pageable).map(InquiryDto::from);
+            case CONTENT -> inquiryRepository.findByContentContaining(searchValue, pageable).map(InquiryDto::from);
+        };
+    }
+
+    @Transactional(readOnly = true)
+    public InquiryDto getInquiry(
+            String inquiryId
+//            UserDto userDto or  UserDetailsImpl userDetails
+    ) {
+        return inquiryRepository.findById(inquiryId).map(InquiryDto::from).orElseThrow();
+    }
+
+
+    public String createInquiry(InquiryDto dto){
+        //유저 조회
+
+        //status 수정
+        Inquiry inquiry = Inquiry.builder()
+//                .user(user)
+                .title(dto.title())
+                .content(dto.content())
+                .status(dto.status())
+                .build();
+        inquiryRepository.save(inquiry);
+        return "created";
+    }
+
+
+    public InquiryDto updateInquiry(String inquiryId, InquiryDto dto) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId).orElseThrow();
+
+        inquiry.setTitle(dto.title());
+        inquiry.setContent(dto.content());
+
+        return InquiryDto.from(inquiryRepository.save(inquiry));
+    }
+
+
+    @Transactional
+    public String deleteInquiry(String inquiryId) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId).orElseThrow();
+        inquiry.setIsPublic(false);
+        inquiry.setIsDeleted(true);
+        inquiry.setDeletedAt(LocalDateTime.now());
+        inquiry.setDeletedBy("CUSTOMER");
+
+        return "deleted";
+    }
+
+
+    //관리자 신고 내용 답변 달기
+    @Transactional
+    public String replyToInquiry(String inquiryId, InquirySetReplyRequest request) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId).orElseThrow();
+
+        //답변 달면 완료로 상태 수정
+        inquiry.setResponse(request.response());
+        inquiry.setStatus(InquiryStatus.COMPLETED);
+        return "replyToInquiry";
+    }
+}


### PR DESCRIPTION
## 고객센터 신고 API 1차 작성

### Feat
- `Inquiry` Entity 수정 : status 필드를 enum 으로 수정함.
- `InquiryStatus` : 처리 중은 생략하고, `접수`, `완료` 상태만 나타나게 작성함.

- 기본적인 CRUD
- SearchType 과 SearchValue 를 parameter 로 받아 조건적 검색 가능 ( 제목, 내용 )

### TODO
- `replyToInquiry` :  `관리자` 만 답변 달 수 있도록 수정
그 외에 다른 컨트롤러에도 유저가 완성되는 대로 권한 조건 수정하기

#53 