### PR TITLE
Fix : 리뷰 시 스토어 리뷰 관련 필드 업데이트 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/sparta/project/delivery/order/service/OrderService.java
+++ b/src/main/java/com/sparta/project/delivery/order/service/OrderService.java
@@ -31,8 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.sparta.project.delivery.common.exception.DeliveryError.*;
-import static com.sparta.project.delivery.common.type.UserRoleEnum.CUSTOMER;
-import static com.sparta.project.delivery.common.type.UserRoleEnum.OWNER;
+import static com.sparta.project.delivery.common.type.UserRoleEnum.*;
 
 @RequiredArgsConstructor
 @Service
@@ -50,7 +49,7 @@ public class OrderService {
         User user = userRepository.findById(userDto.userId())
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
-        if (user.getRole() != CUSTOMER) {
+        if ( !user.getRole().equals(CUSTOMER) && !user.getRole().equals(MASTER) ) {
             throw new CustomException(AUTH_INVALID_CREDENTIALS);
         }
 
@@ -61,7 +60,7 @@ public class OrderService {
         User user = userRepository.findById(userDto.userId())
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
-        if (user.getRole() != OWNER) {
+        if (!user.getRole().equals(OWNER) && !user.getRole().equals(MASTER)) {
             throw new CustomException(AUTH_INVALID_CREDENTIALS);
         }
 

--- a/src/main/java/com/sparta/project/delivery/payment/service/PaymentService.java
+++ b/src/main/java/com/sparta/project/delivery/payment/service/PaymentService.java
@@ -8,17 +8,17 @@ import com.sparta.project.delivery.payment.repository.PaymentRepository;
 import com.sparta.project.delivery.user.User;
 import com.sparta.project.delivery.user.dto.UserDto;
 import com.sparta.project.delivery.user.repository.UserRepository;
-import io.swagger.v3.oas.annotations.servers.Server;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
 
 import static com.sparta.project.delivery.common.exception.DeliveryError.*;
 import static com.sparta.project.delivery.common.type.UserRoleEnum.CUSTOMER;
 
 @RequiredArgsConstructor
-@Server
+@Service
 public class PaymentService {
     private final PaymentRepository paymentRepository;
     private final UserRepository userRepository;

--- a/src/main/java/com/sparta/project/delivery/store/dto/response/StoreResponse.java
+++ b/src/main/java/com/sparta/project/delivery/store/dto/response/StoreResponse.java
@@ -41,11 +41,17 @@ public record StoreResponse(
                         .map(MenuResponse::from)
                         .collect(Collectors.toUnmodifiableSet())
                 )
-                .averageRating(dto.averageRating())
+                .averageRating(roundToOneDecimalPlace(dto.averageRating()))
                 .reviewCount(dto.reviewCount())
                 .isPublic(dto.isPublic())
                 .isDeleted(dto.isDeleted())
                 .build();
     }
 
+    private static Float roundToOneDecimalPlace(Float value) {
+        if (value == 0) {
+            return 0f;
+        }
+        return Math.round(value * 10) / 10.0f;  // 소수점 첫째 자리까지 반올림
+    }
 }

--- a/src/main/java/com/sparta/project/delivery/store/dto/response/StoreResponse.java
+++ b/src/main/java/com/sparta/project/delivery/store/dto/response/StoreResponse.java
@@ -19,6 +19,8 @@ public record StoreResponse(
         String address,
         String description,
         Set<MenuResponse> menus,
+        Float averageRating,
+        Integer reviewCount,
         Boolean isPublic,
         Boolean isDeleted
 ) {
@@ -39,6 +41,8 @@ public record StoreResponse(
                         .map(MenuResponse::from)
                         .collect(Collectors.toUnmodifiableSet())
                 )
+                .averageRating(dto.averageRating())
+                .reviewCount(dto.reviewCount())
                 .isPublic(dto.isPublic())
                 .isDeleted(dto.isDeleted())
                 .build();

--- a/src/test/java/com/sparta/project/delivery/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/sparta/project/delivery/review/service/ReviewServiceTest.java
@@ -1,0 +1,126 @@
+package com.sparta.project.delivery.review.service;
+
+import com.sparta.project.delivery.address.Address;
+import com.sparta.project.delivery.auth.UserDetailsImpl;
+import com.sparta.project.delivery.category.entity.Category;
+import com.sparta.project.delivery.common.exception.CustomException;
+import com.sparta.project.delivery.common.exception.DeliveryError;
+import com.sparta.project.delivery.common.type.City;
+import com.sparta.project.delivery.common.type.DeliveryType;
+import com.sparta.project.delivery.common.type.OrderStatus;
+import com.sparta.project.delivery.common.type.UserRoleEnum;
+import com.sparta.project.delivery.menu.entity.Menu;
+import com.sparta.project.delivery.order.entity.Order;
+import com.sparta.project.delivery.order.repository.OrderRepository;
+import com.sparta.project.delivery.region.entity.Region;
+import com.sparta.project.delivery.review.dto.ReviewDto;
+import com.sparta.project.delivery.review.entity.Review;
+import com.sparta.project.delivery.review.repository.ReviewReportRepository;
+import com.sparta.project.delivery.review.repository.ReviewRepository;
+import com.sparta.project.delivery.store.dto.StoreDto;
+import com.sparta.project.delivery.store.entity.Store;
+import com.sparta.project.delivery.store.repository.StoreRepository;
+import com.sparta.project.delivery.user.User;
+import com.sparta.project.delivery.user.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.sparta.project.delivery.common.exception.DeliveryError.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceTest {
+    @Mock
+    private ReviewRepository reviewRepository;
+    @Mock
+    private ReviewReportRepository reviewReportRepository;
+    @Mock
+    private OrderRepository orderRepository;
+    @Mock
+    private StoreRepository storeRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private ReviewService reviewService;
+
+    private Store store;
+    private User user;
+    private Review review;
+    private Region region;
+    private Category category;
+    private Address address;
+    private ReviewDto reviewDto;
+    private Order order;
+
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder().userId(1L).username("testUser").role(UserRoleEnum.CUSTOMER).build();
+        region = Region.builder().regionId("regionId-123").city(City.SEOUL).siGun("Gangnam").gu("Gangnam")
+                .village("Yeoksam").build();
+        category = Category.builder().categoryId("categoryId-123").name("Food").build();
+        store = Store.builder().storeId("store1").name("Test Store").averageRating(4.0f).user(user).region(region)
+                .category(category).reviewCount(2).menus(Set.of()).build();
+        address = Address.builder().addressId("address1").user(user).address("우리집").build();
+        order = Order.builder().orderId("order1").store(store)
+                .address(address)
+                .user(user).orderMenuList(List.of()).price(10000L).request("")
+                .type(DeliveryType.DELIVERY).status(OrderStatus.DELIVERY_COMPLETED).build();
+        review = Review.builder().reviewId("review1").store(store).order(order).user(user)
+                .rating(5).comment("Great service!").reportFlag(false).build();
+        reviewDto = ReviewDto.from(review);
+    }
+
+    @Test
+    void 리뷰생성성공_AND_음식점필드수정() {
+        //Given
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+        given(orderRepository.findByOrderIdAndUser(anyString(), any(User.class))).willReturn(Optional.of(order));
+        //When
+        reviewService.addReview(reviewDto);
+        //Then
+        assertEquals(3, store.getReviewCount());
+        assertEquals(4.3333335f, store.getAverageRating(), 0.001); // 평점 계산
+
+        verify(storeRepository, times(1)).save(store);
+        verify(reviewRepository, times(1)).save(any(Review.class));
+
+        log.info("Updated Store averageRating: {}", store.getAverageRating());
+        log.info("Updated Store reviewCount: {}", store.getReviewCount());
+    }
+
+    @Test
+    void 리뷰생성시_유저_없으면_에러반환() {
+        // Arrange
+        given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+
+        // Act & Assert
+        CustomException exception = assertThrows(CustomException.class, () -> reviewService.addReview(reviewDto));
+        assertEquals(USER_NOT_FOUND, exception.getError());
+    }
+
+    @Test
+    void 리뷰생성시_주문_없으면_에러반환() {
+        // Arrange
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+        given(orderRepository.findByOrderIdAndUser(anyString(), any(User.class))).willReturn(Optional.empty());
+
+        // Act & Assert
+        CustomException exception = assertThrows(CustomException.class, () -> reviewService.addReview(reviewDto));
+        assertEquals(REVIEW_CREATION_FAILED_NOT_ORDER, exception.getError());
+    }
+
+}

--- a/src/test/java/com/sparta/project/delivery/store/service/StoreServiceTest.java
+++ b/src/test/java/com/sparta/project/delivery/store/service/StoreServiceTest.java
@@ -159,10 +159,11 @@ public class StoreServiceTest {
     @Test
     void 음식점_삭제() {
         when(storeRepository.findById(anyString())).thenReturn(Optional.of(store));
-
+        when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(user));
         storeService.deleteStore(store.getStoreId(), userDetails);
 
         verify(storeRepository, times(1)).findById(anyString());
+        verify(userRepository, times(1)).findByEmail(anyString());
     }
 
 }


### PR DESCRIPTION
Store 전체 조회 시 reviewCount 와 평균 평점을  각각 계산해서 반환하면 각 스토어마다 연결된 리뷰들을 조회하고 계산하기 때문에 N +1 문제가 발생할 수 있다 . 따라서 리뷰 저장 시 스토어에 미리 계산된 평점과 리뷰수를 저장한다.

### Feat
- 리뷰 생성 시 Sttore 의 평균평점(averageRating), 리뷰 수(reivewCount) 를 수정
- 리뷰 생성 시의 상황을 Mocking 하여 테스트 코드를 작성.

Others
- PaymentService 틀린 어노테이션 수정 : @Server -> @Service
- OrderSevice 고객 주문, 가게 주문 조회에 관리자는 접근할 수 있도록 수정

#78 